### PR TITLE
Fix login form creating user twice

### DIFF
--- a/frontend/prebuild/src/app/game/player/player.component.ts
+++ b/frontend/prebuild/src/app/game/player/player.component.ts
@@ -34,6 +34,10 @@ export class PlayerComponent implements OnInit {
   }
 
   get statusImage() {
+    if (!this.player || !this.player.status) {
+      return '';
+    }
+
     let status = this.player.status.toLowerCase();
     if (status === 'none') {
       return '';

--- a/frontend/prebuild/src/app/login/login.component.html
+++ b/frontend/prebuild/src/app/login/login.component.html
@@ -55,7 +55,7 @@
                 <input type="text" id="username" name="username" [(ngModel)]="username" />
               </div>
               <div class="form-item">
-                <button type="submit" id="signin" (click)="loginAsGuest(username)">Sign In As Guest</button>
+                <button type="submit" id="signin">Sign In As Guest</button>
               </div>
               <div class="form-item">
                 <button type="button" (click)="cancelLogin()">Cancel</button>
@@ -89,7 +89,7 @@
                   autocapitalize="off" spellcheck="false">
               </div>
               <div *ngIf="!isSingleParty" class="form-item">
-                <button type="submit" (click)="joinParty()">Join Party</button>
+                <button type="submit">Join Party</button>
               </div>
             </div>
             <div *ngIf="isFullDevice" class="form-group">


### PR DESCRIPTION
The form for guest login had both a `(submit)` handler on the form and a `(click)` handler on the `submit` button, both calling the same function. This caused the function to be called twice.

Solution is to remove the `(click)` handlers as `(submit)` handles both clicking on the submit button and pressing enter when the form has keyboard focus.

In addition, I noticed a ton of "undefined is not an object" errors because the player status was null after a logout, so I added a check for undefined/null/blank player or player status to silence these errors.