### PR TITLE
Enable MP Metrics and add some application specific metrics

### DIFF
--- a/auth-service/src/main/java/org/libertybikes/auth/service/github/GitHubCallback.java
+++ b/auth-service/src/main/java/org/libertybikes/auth/service/github/GitHubCallback.java
@@ -56,7 +56,7 @@ public class GitHubCallback extends JwtAuth {
              name = "num_github_logins",
              monotonic = true,
              displayName = "Number of Github Logins",
-             description = "Metrics to show how many times a user has logged in through Github Auth.",
+             description = "How many times a user has logged in through Github Auth.",
              absolute = true)
     public Response getGitHubCallbackURL(@Context HttpServletRequest request) throws URISyntaxException {
         try {

--- a/auth-service/src/main/java/org/libertybikes/auth/service/github/GitHubCallback.java
+++ b/auth-service/src/main/java/org/libertybikes/auth/service/github/GitHubCallback.java
@@ -18,6 +18,8 @@ import javax.ws.rs.Path;
 import javax.ws.rs.core.Context;
 import javax.ws.rs.core.Response;
 
+import org.eclipse.microprofile.metrics.MetricUnits;
+import org.eclipse.microprofile.metrics.annotation.Counted;
 import org.libertybikes.auth.service.ConfigBean;
 import org.libertybikes.auth.service.JwtAuth;
 import org.libertybikes.auth.service.github.GitHubOAuthAPI.GithubTokenResponse;
@@ -50,6 +52,12 @@ public class GitHubCallback extends JwtAuth {
     }
 
     @GET
+    @Counted(unit = MetricUnits.NONE,
+             name = "num_github_logins",
+             monotonic = true,
+             displayName = "Number of Github Logins",
+             description = "Metrics to show how many times a user has logged in through Github Auth.",
+             absolute = true)
     public Response getGitHubCallbackURL(@Context HttpServletRequest request) throws URISyntaxException {
         try {
             String githubCode = request.getParameter("code");

--- a/auth-service/src/main/java/org/libertybikes/auth/service/google/GoogleCallback.java
+++ b/auth-service/src/main/java/org/libertybikes/auth/service/google/GoogleCallback.java
@@ -18,6 +18,8 @@ import javax.ws.rs.core.Context;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 
+import org.eclipse.microprofile.metrics.MetricUnits;
+import org.eclipse.microprofile.metrics.annotation.Counted;
 import org.libertybikes.auth.service.ConfigBean;
 import org.libertybikes.auth.service.JwtAuth;
 
@@ -85,6 +87,12 @@ public class GoogleCallback extends JwtAuth {
     }
 
     @GET
+    @Counted(unit = MetricUnits.NONE,
+             name = "num_google_logins",
+             monotonic = true,
+             displayName = "Number of Google Logins",
+             description = "Metrics to show how many times a user has logged in through Google Auth.",
+             absolute = true)
     public Response getGoogleAuthURL(@Context HttpServletRequest request) throws IOException, URISyntaxException {
         // google calls us back at this app when a user has finished authing with them.
         // when it calls us back here, it passes an oauth_verifier token that we

--- a/auth-service/src/main/java/org/libertybikes/auth/service/google/GoogleCallback.java
+++ b/auth-service/src/main/java/org/libertybikes/auth/service/google/GoogleCallback.java
@@ -91,7 +91,7 @@ public class GoogleCallback extends JwtAuth {
              name = "num_google_logins",
              monotonic = true,
              displayName = "Number of Google Logins",
-             description = "Metrics to show how many times a user has logged in through Google Auth.",
+             description = "How many times a user has logged in through Google Auth.",
              absolute = true)
     public Response getGoogleAuthURL(@Context HttpServletRequest request) throws IOException, URISyntaxException {
         // google calls us back at this app when a user has finished authing with them.

--- a/auth-service/src/main/java/org/libertybikes/auth/service/twitter/TwitterCallback.java
+++ b/auth-service/src/main/java/org/libertybikes/auth/service/twitter/TwitterCallback.java
@@ -37,7 +37,7 @@ public class TwitterCallback extends JwtAuth {
              name = "num_twitter_logins",
              monotonic = true,
              displayName = "Number of Twitter Logins",
-             description = "Metrics to show how many times a user has logged in through Twitter Auth.",
+             description = "How many times a user has logged in through Twitter Auth.",
              absolute = true)
     public Response getTwitterCallbackURL(@Context HttpServletRequest request) throws URISyntaxException {
         try {

--- a/auth-service/src/main/java/org/libertybikes/auth/service/twitter/TwitterCallback.java
+++ b/auth-service/src/main/java/org/libertybikes/auth/service/twitter/TwitterCallback.java
@@ -13,6 +13,8 @@ import javax.ws.rs.Path;
 import javax.ws.rs.core.Context;
 import javax.ws.rs.core.Response;
 
+import org.eclipse.microprofile.metrics.MetricUnits;
+import org.eclipse.microprofile.metrics.annotation.Counted;
 import org.libertybikes.auth.service.ConfigBean;
 import org.libertybikes.auth.service.JwtAuth;
 
@@ -31,6 +33,12 @@ public class TwitterCallback extends JwtAuth {
     ConfigBean config;
 
     @GET
+    @Counted(unit = MetricUnits.NONE,
+             name = "num_twitter_logins",
+             monotonic = true,
+             displayName = "Number of Twitter Logins",
+             description = "Metrics to show how many times a user has logged in through Twitter Auth.",
+             absolute = true)
     public Response getTwitterCallbackURL(@Context HttpServletRequest request) throws URISyntaxException {
         try {
             Twitter twitter = (Twitter) request.getSession().getAttribute("twitter");

--- a/auth-service/src/main/liberty/config/server.xml
+++ b/auth-service/src/main/liberty/config/server.xml
@@ -10,7 +10,10 @@
         <feature>mpJwt-1.0</feature>
         <feature>mpRestClient-1.0</feature>
         <feature>mpOpenAPI-1.0</feature>
+        <feature>mpMetrics-1.1</feature>
     </featureManager>
+    
+    <mpMetrics authentication="false"/>
 
     <httpEndpoint id="defaultHttpEndpoint" host="*" httpPort="${httpPort}" httpsPort="${httpsPort}" />
                   

--- a/game-service/src/main/java/org/libertybikes/game/core/GameBoard.java
+++ b/game-service/src/main/java/org/libertybikes/game/core/GameBoard.java
@@ -186,7 +186,7 @@ public class GameBoard {
 
     public void broadcastToAI() {
         for (Player p : players) {
-            if (p.isAlive()) {
+            if (p.isAlive() && !p.isRealPlayer()) {
                 short[][] boardCopy = board.clone();
                 p.processAIMove(boardCopy);
             }

--- a/game-service/src/main/java/org/libertybikes/game/metric/GameMetrics.java
+++ b/game-service/src/main/java/org/libertybikes/game/metric/GameMetrics.java
@@ -1,0 +1,102 @@
+/**
+ *
+ */
+package org.libertybikes.game.metric;
+
+import javax.enterprise.inject.spi.CDI;
+
+import org.eclipse.microprofile.metrics.Metadata;
+import org.eclipse.microprofile.metrics.MetricRegistry;
+import org.eclipse.microprofile.metrics.MetricType;
+import org.eclipse.microprofile.metrics.MetricUnits;
+import org.eclipse.microprofile.metrics.Timer.Context;
+
+public class GameMetrics {
+    // MpMetric Metadatas
+    public static final Metadata currentRoundsCounter = new Metadata("current_num_of_rounds", // name
+                    "Current Number of Rounds", // display name
+                    "Number of rounds currently running", // description
+                    MetricType.COUNTER, // type
+                    MetricUnits.NONE); // units
+
+    public static final Metadata totalRoundsCounter = new Metadata("total_num_of_rounds", // name
+                    "Total Number of Rounds", // display name
+                    "Number of rounds that have been created", // description
+                    MetricType.COUNTER, // type
+                    MetricUnits.NONE); // units
+
+    public static final Metadata currentPlayersCounter = new Metadata("current_num_of_players", // name
+                    "Current Number of Players", // display name
+                    "Number of players that are currently playing in a round", // description
+                    MetricType.COUNTER, // type
+                    MetricUnits.NONE); // units
+
+    public static final Metadata totalPlayersCounter = new Metadata("total_num_of_players", // name
+                    "Total Number of Players That Have Played", // display name
+                    "Number of players that have played in a round, requeuing and replaying increases the count", // description
+                    MetricType.COUNTER, // type
+                    MetricUnits.NONE); // units
+
+    public static final Metadata totalMobilePlayersCounter = new Metadata("total_num_of_mobile_players", // name
+                    "Total Number of Mobile Players That Have Played", // display name
+                    "Number of mobile players that have played in a round, requeuing and replaying increases the count", // description
+                    MetricType.COUNTER, // type
+                    MetricUnits.NONE); // units
+
+    public static final Metadata gameRoundTimerMetadata = new Metadata("game_round_timer", // name
+                    "Game Round Timer", // display name
+                    "The Time Game Rounds Last", // description
+                    MetricType.TIMER, // type
+                    MetricUnits.SECONDS); // units
+
+    public static final Metadata currentPartiesCounterMetadata = new Metadata("current_number_of_parties", // name
+                    "Current Number of Parties", // display name
+                    "Number of parties currently running", // description
+                    MetricType.COUNTER, // type
+                    MetricUnits.NONE); // units
+
+    public static final Metadata currentQueuedPlayersCounter = new Metadata("current_num_of_players_in_queue", // name
+                    "Current Number of Players Waiting In A Queue", // display name
+                    "Number of players that are currently waiting in a queue", // description
+                    MetricType.COUNTER, // type
+                    MetricUnits.NONE); // units
+
+    public static final Metadata openWebsocketTimerMetadata = new Metadata("open_game_websocket_timer", // name
+                    "Open Game Round Websocket Timer", // display name
+                    "The Time Game Round Websockets Are Open", // description
+                    MetricType.TIMER, // type
+                    MetricUnits.SECONDS); // units
+
+    private static MetricRegistry registry;
+
+    private static MetricRegistry getRegistry() {
+        try {
+            registry = CDI.current().select(MetricRegistry.class).get();
+            System.out.println("MetricRegistry configured");
+            return registry;
+        } catch (IllegalStateException ise) {
+            System.out.println("WARNING: Unable to locate CDIProvider");
+            ise.printStackTrace();
+        }
+        return null;
+    }
+
+    public static void counterInc(Metadata metricMetadata) {
+        if (registry != null || (getRegistry() != null)) {
+            registry.counter(metricMetadata).inc();
+        }
+    }
+
+    public static void counterDec(Metadata metricMetadata) {
+        if (registry != null || (getRegistry() != null)) {
+            registry.counter(metricMetadata).dec();
+        }
+    }
+
+    public static Context timerStart(Metadata metricMetadata) {
+        if (registry != null || (getRegistry() != null)) {
+            return registry.timer(metricMetadata).time();
+        }
+        return null;
+    }
+}

--- a/game-service/src/main/java/org/libertybikes/game/party/Party.java
+++ b/game-service/src/main/java/org/libertybikes/game/party/Party.java
@@ -10,14 +10,11 @@ import javax.json.bind.annotation.JsonbTransient;
 import javax.ws.rs.sse.Sse;
 import javax.ws.rs.sse.SseEventSink;
 
-import org.eclipse.microprofile.metrics.Counter;
-import org.eclipse.microprofile.metrics.Metadata;
-import org.eclipse.microprofile.metrics.MetricRegistry;
-import org.eclipse.microprofile.metrics.MetricType;
 import org.eclipse.microprofile.metrics.MetricUnits;
 import org.eclipse.microprofile.metrics.annotation.Counted;
 import org.libertybikes.game.core.GameRound;
 import org.libertybikes.game.core.GameRound.LifecycleCallback;
+import org.libertybikes.game.metric.GameMetrics;
 import org.libertybikes.game.round.service.GameRoundService;
 
 @Dependent
@@ -35,26 +32,14 @@ public class Party {
     private final PartyQueue queue = new PartyQueue(this);
     private volatile GameRound currentRound;
 
-    Metadata currentPartiesCounterMetadata = new Metadata("current_number_of_parties", // name
-                    "Current Number of Parties", // display name
-                    "Number of parties currently running", // description
-                    MetricType.COUNTER, // type
-                    MetricUnits.NONE); // units
-
-    @Inject
-    private MetricRegistry registry;
-
-    private Counter currentPartiesCounter;
-
     @PostConstruct
     public void postConstruct() {
-        currentPartiesCounter = registry.counter(currentPartiesCounterMetadata);
-        currentPartiesCounter.inc();
+        GameMetrics.counterInc(GameMetrics.currentPartiesCounterMetadata);
     }
 
     @PreDestroy
     public void preDestroy() {
-        currentPartiesCounter.dec();
+        GameMetrics.counterDec(GameMetrics.currentPartiesCounterMetadata);
     }
 
     @Inject

--- a/game-service/src/main/java/org/libertybikes/game/party/PartyQueue.java
+++ b/game-service/src/main/java/org/libertybikes/game/party/PartyQueue.java
@@ -3,11 +3,16 @@ package org.libertybikes.game.party;
 import java.util.Objects;
 import java.util.concurrent.ConcurrentLinkedDeque;
 
+import javax.enterprise.inject.spi.CDI;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.sse.OutboundSseEvent;
 import javax.ws.rs.sse.Sse;
 import javax.ws.rs.sse.SseEventSink;
 
+import org.eclipse.microprofile.metrics.Metadata;
+import org.eclipse.microprofile.metrics.MetricRegistry;
+import org.eclipse.microprofile.metrics.MetricType;
+import org.eclipse.microprofile.metrics.MetricUnits;
 import org.libertybikes.game.core.GameRound;
 import org.libertybikes.game.core.OutboundMessage;
 import org.libertybikes.game.core.Player;
@@ -16,6 +21,18 @@ public class PartyQueue {
 
     private final ConcurrentLinkedDeque<QueuedClient> waitingPlayers = new ConcurrentLinkedDeque<>();
     private final Party party;
+
+    private Metadata currentPlayersCounter = new Metadata("current_num_of_players_in_queue", // name
+                    "Current Number of Players Waiting In A Queue", // display name
+                    "Number of players that are currently waiting in a queue", // description
+                    MetricType.COUNTER, // type
+                    MetricUnits.NONE); // units
+
+    private MetricRegistry registry;
+
+    private MetricRegistry getRegistry() {
+        return registry == null ? registry = CDI.current().select(MetricRegistry.class).get() : registry;
+    }
 
     public PartyQueue(Party p) {
         this.party = p;
@@ -26,9 +43,12 @@ public class PartyQueue {
         // If this client was already in the queue, remove them and add them at the end
         if (waitingPlayers.removeFirstOccurrence(client)) {
             party.log("Removed client " + playerId + " from queue before adding at end");
+            getRegistry().counter(currentPlayersCounter).dec();
         }
         party.log("Adding client " + playerId + " into the queue in position " + client.queuePosition());
         waitingPlayers.add(client);
+
+        getRegistry().counter(currentPlayersCounter).inc();
         if (party.getCurrentRound().isOpen())
             promoteClients();
         else
@@ -42,6 +62,7 @@ public class PartyQueue {
             QueuedClient first = waitingPlayers.pollFirst();
             if (first != null) {
                 first.promoteToGame(newRound.id);
+                getRegistry().counter(currentPlayersCounter).dec();
             }
         }
         for (QueuedClient client : waitingPlayers)
@@ -51,8 +72,10 @@ public class PartyQueue {
     public void close() {
         party.log("Closing party queue");
         QueuedClient client = null;
-        while ((client = waitingPlayers.pollFirst()) != null)
+        while ((client = waitingPlayers.pollFirst()) != null) {
             client.close();
+            getRegistry().counter(currentPlayersCounter).dec();
+        }
     }
 
     private class QueuedClient {

--- a/game-service/src/main/java/org/libertybikes/game/round/service/GameRoundService.java
+++ b/game-service/src/main/java/org/libertybikes/game/round/service/GameRoundService.java
@@ -48,17 +48,12 @@ public class GameRoundService {
 
     @POST
     public GameRound createRoundById(@QueryParam("gameId") String gameId) {
-        if (allRounds.containsKey(gameId)) {
-            System.out.println("Round " + gameId + " already exists, returning it");
-            return allRounds.get(gameId);
-        }
-        GameRound newRound = new GameRound(gameId);
-        allRounds.put(gameId, newRound);
-        System.out.println("Created round id=" + newRound.id);
+        GameRound round = allRounds.computeIfAbsent(gameId, k -> new GameRound(gameId));
+        System.out.println("Created round id=" + round.id);
         if (allRounds.size() > 5)
             System.out.println("WARNING: Found " + allRounds.size() + " active games in GameRoundService. " +
                                "They are probably not being cleaned up properly: " + allRounds.keySet());
-        return newRound;
+        return round;
     }
 
     @GET

--- a/game-service/src/main/java/org/libertybikes/game/round/service/GameRoundService.java
+++ b/game-service/src/main/java/org/libertybikes/game/round/service/GameRoundService.java
@@ -48,14 +48,17 @@ public class GameRoundService {
 
     @POST
     public GameRound createRoundById(@QueryParam("gameId") String gameId) {
+        if (allRounds.containsKey(gameId)) {
+            System.out.println("Round " + gameId + " already exists, returning it");
+            return allRounds.get(gameId);
+        }
         GameRound newRound = new GameRound(gameId);
-        GameRound existingRound = allRounds.putIfAbsent(gameId, newRound);
-        GameRound round = existingRound == null ? newRound : existingRound;
-        System.out.println("Created round id=" + round.id);
+        allRounds.put(gameId, newRound);
+        System.out.println("Created round id=" + newRound.id);
         if (allRounds.size() > 5)
             System.out.println("WARNING: Found " + allRounds.size() + " active games in GameRoundService. " +
                                "They are probably not being cleaned up properly: " + allRounds.keySet());
-        return round;
+        return newRound;
     }
 
     @GET

--- a/game-service/src/main/liberty/config/server.xml
+++ b/game-service/src/main/liberty/config/server.xml
@@ -15,8 +15,6 @@
     </featureManager>
     
     <mpMetrics authentication="false"/>
-    
-    <logging traceSpecification="com.ibm.ws.microprofile.metrics*=all"/>
 
     <httpEndpoint id="defaultHttpEndpoint" host="*" httpPort="${httpPort}" httpsPort="${httpsPort}" />
     

--- a/game-service/src/main/liberty/config/server.xml
+++ b/game-service/src/main/liberty/config/server.xml
@@ -11,7 +11,12 @@
         <feature>mpRestClient-1.1</feature>
         <feature>mpOpenAPI-1.0</feature>
         <feature>websocket-1.1</feature>
+        <feature>mpMetrics-1.1</feature>
     </featureManager>
+    
+    <mpMetrics authentication="false"/>
+    
+    <logging traceSpecification="com.ibm.ws.microprofile.metrics*=all"/>
 
     <httpEndpoint id="defaultHttpEndpoint" host="*" httpPort="${httpPort}" httpsPort="${httpsPort}" />
     

--- a/player-service/src/main/java/org/libertybikes/player/service/PlayerService.java
+++ b/player-service/src/main/java/org/libertybikes/player/service/PlayerService.java
@@ -14,6 +14,10 @@ import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.MediaType;
 
 import org.eclipse.microprofile.jwt.JsonWebToken;
+import org.eclipse.microprofile.metrics.Metadata;
+import org.eclipse.microprofile.metrics.MetricRegistry;
+import org.eclipse.microprofile.metrics.MetricType;
+import org.eclipse.microprofile.metrics.MetricUnits;
 import org.libertybikes.player.data.PlayerDB;
 
 @Path("/player")
@@ -32,6 +36,15 @@ public class PlayerService {
         return db.getAll();
     }
 
+    @Inject
+    private MetricRegistry registry;
+
+    private Metadata numLoginsCounter = new Metadata("num_player_logins", // name
+                    "Number of Total Logins", // display name
+                    "Metrics to show how many times a user has logged in.", // description
+                    MetricType.COUNTER, // type
+                    MetricUnits.NONE); // units
+
     @POST
     @Produces(MediaType.TEXT_HTML)
     public String createPlayer(@QueryParam("name") String name, @QueryParam("id") String id) {
@@ -49,6 +62,10 @@ public class PlayerService {
             System.out.println("Created a new player with id=" + p.id);
         else
             System.out.println("A player already existed with id=" + p.id);
+
+        if (id != null && registry != null) {
+            registry.counter(numLoginsCounter).inc();
+        }
         return p.id;
     }
 

--- a/player-service/src/main/java/org/libertybikes/player/service/PlayerService.java
+++ b/player-service/src/main/java/org/libertybikes/player/service/PlayerService.java
@@ -39,9 +39,9 @@ public class PlayerService {
     @Inject
     private MetricRegistry registry;
 
-    private Metadata numLoginsCounter = new Metadata("num_player_logins", // name
+    private static final Metadata numLoginsCounter = new Metadata("num_player_logins", // name
                     "Number of Total Logins", // display name
-                    "Metrics to show how many times a user has logged in.", // description
+                    "How many times a user has logged in.", // description
                     MetricType.COUNTER, // type
                     MetricUnits.NONE); // units
 

--- a/player-service/src/main/liberty/config/server.xml
+++ b/player-service/src/main/liberty/config/server.xml
@@ -9,7 +9,10 @@
         <feature>mpConfig-1.3</feature>
         <feature>mpJwt-1.0</feature>
         <feature>mpOpenAPI-1.0</feature>
+        <feature>mpMetrics-1.1</feature>
     </featureManager>
+
+	<mpMetrics authentication="false"/>
 
     <applicationManager autoExpand="true"/>
     


### PR DESCRIPTION
Added the following Application Metrics:

  Count logins from Google, Twitter, Facebook, NoAuth -> Counter
  Num of Players that have played -> Counter
  Total Num of Parties Created -> Counter
  Total Num of Round Created -> Counter
  Num of rounds that exist right now ->Counter
  Num of players connected right now -> Counter
  Average Round length -> Timer
  Num of players in a queue -> Counter
  GameRoundWebsock.onMessage() -> Metered
  Average Total Time a Websocket is open -> Timer
  Count mobile vs non mobile players -> Counter