### PR TITLE
Tweak animations on login screen

### DIFF
--- a/frontend/prebuild/src/app/login/login.component.scss
+++ b/frontend/prebuild/src/app/login/login.component.scss
@@ -30,7 +30,7 @@ h2 {
 .glow {
   transition: all 0.3s ease-in-out;
 
-  &:hover {
+  &:hover, &:focus {
     filter: drop-shadow(0 0 4px #fff);
   }
 }
@@ -69,10 +69,11 @@ h2 {
     background: rgba(0, 0, 0, 0.2);
     border-bottom: 1px solid #bbb;
     border-radius: 0px;
-    transition: all 0.3s ease-in-out;
+    transition: all 0.15s ease-in-out;
 
-    &:hover {
+    &:hover, &:focus {
       text-shadow: 0 0 5px #fff;
+      background-color: rgba(75, 75, 75, 0.2);
     }
 
     &:focus {

--- a/frontend/prebuild/src/app/slider/slider.component.scss
+++ b/frontend/prebuild/src/app/slider/slider.component.scss
@@ -1,6 +1,5 @@
 :host {
   display: block;
-  overflow: hidden;
 }
 
 .parent {

--- a/frontend/prebuild/src/app/slider/slider.component.ts
+++ b/frontend/prebuild/src/app/slider/slider.component.ts
@@ -1,5 +1,5 @@
 import { Component, OnInit, ChangeDetectionStrategy, Input } from '@angular/core';
-import { trigger, state, style, transition, animate, query, group } from '@angular/animations';
+import { trigger, state, style, transition, animate, query, group, animateChild } from '@angular/animations';
 
 @Component({
   selector: 'app-slider',
@@ -13,12 +13,17 @@ import { trigger, state, style, transition, animate, query, group } from '@angul
       state('right', style({ transform: 'translateX(-50%)' })),
       state('queue', style({ transform: 'translateX(-75%)'})),
       transition('void => *', animate(0)),
-      transition('* => *', animate(300))
+      transition('* => *', [
+        group([
+          query('@fade', animateChild()),
+          animate('300ms ease-out')
+        ])
+      ])
     ]),
     trigger('fade', [
-      state('active', style({ opacity: 1 })),
-      state('inactive', style({ opacity: 0 })),
-      transition('* => *', animate(300))
+      state('active', style({ visibility: 'visible', opacity: 1 })),
+      state('inactive', style({ visibility: 'hidden', opacity: 0 })),
+      transition('* => *', animate('200ms'))
     ])
   ]
 })

--- a/frontend/prebuild/src/styles.scss
+++ b/frontend/prebuild/src/styles.scss
@@ -33,15 +33,17 @@ button {
   background-color: rgba(0, 0, 0, 0.2);
   border: 1px solid #ccc;
   color: #fff;
-  transition: all 0.3s ease-in-out;
+  transition: all 0.15s ease-in-out;
 }
 
 button:disabled {
   opacity: 0.5;
 }
 
-button:hover:enabled {
+button:hover:enabled, button:focus:enabled {
   text-shadow: 0 0 5px #fff;
+  background-color: rgba(50, 50, 50, 0.2);
+  border-color: #fff;
 }
 
 /* Navigation link styles */


### PR DESCRIPTION
Few tweaks to the animations. Make it more apparent when interactable form elements are hovered or focused, and get the fade component of the panel transition that's always been in the code actually working.

![Screen Recording 2019-08-09 at 12 18 26 PM 2019-08-09 12_21_17](https://user-images.githubusercontent.com/1577201/62797160-9773e780-baa0-11e9-966e-ba002eb963ec.gif)
