### PR TITLE
 Add script for running just monitoring services in containers

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,12 @@ Builds all microservice applications and deploys them to locally running liberty
 
 Any code changes that are made in an eclipse environment with auto-build enabled will automatically publish content to the loose application, meaning no server restarts should be required between code changes.
 
+To start the monitoring services, you must have Docker installed. They can be started with:
+
+```
+./startMonitoring.sh
+```
+
 To stop all liberty servers, issue the command:
 
 ```

--- a/build.gradle
+++ b/build.gradle
@@ -71,7 +71,7 @@ subprojects {
         testCompile group: 'junit', name: 'junit', version: '4.12'
         testCompile group: 'org.eclipse', name: 'yasson', version: '1.0.3'
         testCompile group: 'org.glassfish', name: 'jakarta.json', version: '1.1.5'
-        libertyRuntime group: 'io.openliberty', name: 'openliberty-runtime', version: '[19.0.0.5,)'
+        libertyRuntime group: 'io.openliberty', name: 'openliberty-runtime', version: '[19.0.0.8,)'
     }
     
     eclipse {

--- a/game-service/src/main/java/org/libertybikes/game/round/service/GameRoundService.java
+++ b/game-service/src/main/java/org/libertybikes/game/round/service/GameRoundService.java
@@ -40,7 +40,7 @@ public class GameRoundService {
         GameRound p = new GameRound();
         allRounds.put(p.id, p);
         System.out.println("Created round id=" + p.id);
-        if (allRounds.size() > 5)
+        if (allRounds.size() > 35)
             System.out.println("WARNING: Found " + allRounds.size() + " active games in GameRoundService. " +
                                "They are probably not being cleaned up properly: " + allRounds.keySet());
         return p.id;
@@ -50,7 +50,7 @@ public class GameRoundService {
     public GameRound createRoundById(@QueryParam("gameId") String gameId) {
         GameRound round = allRounds.computeIfAbsent(gameId, k -> new GameRound(gameId));
         System.out.println("Created round id=" + round.id);
-        if (allRounds.size() > 5)
+        if (allRounds.size() > 35)
             System.out.println("WARNING: Found " + allRounds.size() + " active games in GameRoundService. " +
                                "They are probably not being cleaned up properly: " + allRounds.keySet());
         return round;
@@ -101,12 +101,12 @@ public class GameRoundService {
         String roundId = round.id;
         if (round.isOpen())
             round.gameState = State.FINISHED;
-        System.out.println("Scheduling round id=" + roundId + " for deletion in 5 minutes");
+        System.out.println("Scheduling round id=" + roundId + " for deletion in 15 minutes");
         // Do not immediately delete rounds in order to give players/spectators time to move along to the next game
         exec.schedule(() -> {
             allRounds.remove(roundId);
             System.out.println("Deleted round id=" + roundId);
-        }, 5, TimeUnit.MINUTES);
+        }, 15, TimeUnit.MINUTES);
     }
 
 }

--- a/monitoring/datasource-local/datasource.yml
+++ b/monitoring/datasource-local/datasource.yml
@@ -1,0 +1,50 @@
+# config file version
+apiVersion: 1
+
+# list of datasources that should be deleted from the database
+deleteDatasources:
+  - name: Prometheus
+    orgId: 1
+
+# list of datasources to insert/update depending
+# whats available in the database
+datasources:
+  # <string, required> name of the datasource. Required
+  - name: Prometheus
+    # <string, required> datasource type. Required
+    type: prometheus
+    # <string, required> access mode. direct or proxy. Required
+    access: direct
+    # <int> org id. will default to orgId 1 if not specified
+    orgId: 1
+    # <string> url
+    url: http://localhost:9090
+    # <string> database password, if used
+    password:
+    # <string> database user, if used
+    user:
+    # <string> database name, if used
+    database:
+    # <bool> enable/disable basic auth
+    basicAuth: false
+    # <string> basic auth username
+    basicAuthUser: admin
+    # <string> basic auth password
+    basicAuthPassword: admin
+    # <bool> enable/disable with credentials headers
+    withCredentials:
+    # <bool> mark as default datasource. Max one per org
+    isDefault: true
+    # <map> fields that will be converted to json and stored in json_data
+    jsonData:
+      graphiteVersion: "1.1"
+      tlsAuth: false
+      tlsAuthWithCACert: false
+    # <string> json object of data that will be encrypted.
+    secureJsonData:
+      tlsCACert: "..."
+      tlsClientCert: "..."
+      tlsClientKey: "..."
+    version: 1
+    # <bool> allow users to edit datasources from the UI.
+    editable: true

--- a/startMonitoring.sh
+++ b/startMonitoring.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+
+LOCAL_HOST=`ifconfig | grep -Eo 'inet (addr:)?([0-9]*\.){3}[0-9]*' | grep -Eo '([0-9]*\.){3}[0-9]*' | grep -v '127.0.0.1'`
+echo "This hostname is: $LOCAL_HOST"
+
+PROM_LOCAL_CONFIG=`pwd`/build/monitoring/prometheus-local
+mkdir -p $PROM_LOCAL_CONFIG
+rm $PROM_LOCAL_CONFIG/prometheus.yml 2> /dev/null
+echo "Building local config file prometheus config at: $PROM_LOCAL_CONFIG"
+sed \
+  -e "s/'game:/'$LOCAL_HOST:/g" \
+  -e "s/'player:/'$LOCAL_HOST:/g" \
+  -e "s/'auth:/'$LOCAL_HOST:/g" \
+  -e "s/'frontend:/'$LOCAL_HOST:/g" \
+  monitoring/prometheus/prometheus.yml > \
+  $PROM_LOCAL_CONFIG/prometheus.yml
+
+echo "Starting prometheus"
+docker stop lb-prometheus 2> /dev/null
+docker run \
+  --name lb-prometheus \
+  --rm \
+  -d \
+  -p 9090:9090 \
+  -v $PROM_LOCAL_CONFIG:/etc/prometheus \
+  prom/prometheus:v2.4.0
+  
+echo "Starting grafana"
+docker stop lb-grafana 2> /dev/null
+docker run \
+  --name lb-grafana \
+  --rm \
+  -d \
+  -p 3000:3000 \
+  -e  GF_INSTALL_PLUGINS=flant-statusmap-panel \
+  -v `pwd`/monitoring/datasource-local:/etc/grafana/provisioning/datasources \
+  -v `pwd`/monitoring/dashboardList:/etc/grafana/provisioning/dashboards \
+  -v `pwd`/monitoring/grafanaDashboardConfig:/var/lib/grafana/dashboards \
+  grafana/grafana:5.2.4
+
+echo "########################################################"  
+echo "Metrics dashboard available at http://localhost:3000"
+echo "Log in with user=admin password=admin"
+echo "########################################################"


### PR DESCRIPTION
We can already run all services in containers using `./gradlew dockerStart`, but sometimes it is nice to run the Liberty servers on bare-metal so we can take advantage of hot updates and more easily view logs and server config. 

This PR adds a new script at `./startMonitoring.sh` which will start up just the Grafana and Prometheus containers, pointed at locally running Liberty instances.