### PR TITLE
Add dependency composeUp -> addPostgresqlToBuild

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -98,6 +98,7 @@ subprojects {
     libertyDebug.dependsOn 'libertyStop'    
     libertyStart.dependsOn 'libertyStop', 'test'
     libertyRun.dependsOn   'libertyStop'
+    composeUp.dependsOn ':player-service:addPostgresqlToBuild'
     
     task debug { dependsOn 'libertyDebug' }
     task start { dependsOn 'libertyStart' }


### PR DESCRIPTION
Fixes #234 

Need to copy the jar to the build folder in order for the image build to succeed. That step depends on the assemble step, but composeUp does not include assemble in its dependency tree. 

I'm open to other ways to set up the dependencies, just suggest.