### PR TITLE
Add missing task dependencies

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -42,7 +42,7 @@ task dockerStop {
 
 composeUp {
     subprojects.each {
-        dependsOn("${it.name}:war")
+        dependsOn("${it.name}:assemble")
     }
 }
 

--- a/player-service/build.gradle
+++ b/player-service/build.gradle
@@ -23,7 +23,7 @@ dependencies {
 }
 
 task addPostgresqlToServer(type: Copy) {
-  shouldRunAfter libertyCreate
+  mustRunAfter libertyCreate
   from configurations.postgresql
   into "${rootProject.buildDir}/wlp/usr/servers/${liberty.server.name}/postgresql"
 }


### PR DESCRIPTION
Need to use `mustRunAfter` instead of `shouldRunAfter` for the `addPostgreSqlToServer` task, because it was running before Liberty was installed and causing the `installLiberty` UP-TO-DATE check to think that Liberty was already installed