### PR TITLE
Fix bug where game service would get stuck on a deleted round

### DIFF
--- a/game-service/src/main/java/org/libertybikes/game/round/service/GameRoundService.java
+++ b/game-service/src/main/java/org/libertybikes/game/round/service/GameRoundService.java
@@ -18,7 +18,6 @@ import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.MediaType;
 
 import org.libertybikes.game.core.GameRound;
-import org.libertybikes.game.core.GameRound.State;
 
 @Path("/round")
 @ApplicationScoped
@@ -91,7 +90,7 @@ public class GameRoundService {
         if (isPlayer && nextRound.isStarted())
             return requeue(nextRound.id, isPlayer);
         // If next round is already done, requeue ahead to next game
-        else if (nextRound.gameState == GameRound.State.FINISHED)
+        else if (nextRound.getGameState() == GameRound.State.FINISHED)
             return requeue(nextRound.id, isPlayer);
         else
             return nextRound.id;
@@ -100,7 +99,7 @@ public class GameRoundService {
     public void deleteRound(GameRound round) {
         String roundId = round.id;
         if (round.isOpen())
-            round.gameState = State.FINISHED;
+            round.endGame();
         System.out.println("Scheduling round id=" + roundId + " for deletion in 15 minutes");
         // Do not immediately delete rounds in order to give players/spectators time to move along to the next game
         exec.schedule(() -> {

--- a/game-service/src/main/java/org/libertybikes/game/round/service/GameRoundWebsocket.java
+++ b/game-service/src/main/java/org/libertybikes/game/round/service/GameRoundWebsocket.java
@@ -4,8 +4,6 @@
 package org.libertybikes.game.round.service;
 
 import java.io.IOException;
-import java.util.List;
-import java.util.Map;
 import java.util.Set;
 
 import javax.enterprise.context.Dependent;
@@ -78,7 +76,7 @@ public class GameRoundWebsocket {
         try {
             final InboundMessage msg = jsonb.fromJson(message, InboundMessage.class);
             final GameRound round = gameSvc.getRound(roundId);
-            if (round == null || round.gameState == State.FINISHED) {
+            if (round == null || round.getGameState() == State.FINISHED) {
                 log(roundId, "[onMessage] Received message for round that did not exist or has completed.  Closing this websocket connection.");
                 if (round == null)
                     sendToClient(session, new OutboundMessage.ErrorEvent("Round " + roundId + " did not exist."));
@@ -101,7 +99,6 @@ public class GameRoundWebsocket {
                 if (!round.addPlayer(session, msg.playerJoinedId, playerResponse.name, msg.hasGameBoard == null ? true : msg.hasGameBoard))
                     sendToClient(session, new OutboundMessage.ErrorEvent("Unable to add player " + playerResponse.name
                                                                          + " to game. This is probably because someone else with the same name is already in the game."));
-
 
             } else if (Boolean.TRUE == msg.isSpectator) {
                 round.addSpectator(session);


### PR DESCRIPTION
Ryan pointed out a bug where if you do:
 - host game
 - close game tab while countdown is still going
 - open new tab
 - try to play/host a new game

The game-service would get stuck saying round XXXX did not exist. This was because when we deleted an unstarted game in `GameRoundService.deleteRound()` we just set the game state to `FINISHED` and didn't go through the `GameRound.endGame()` code which would take care of the round cleanup including invoking the callback that advanced the party to next round.