### PR TITLE
Allow players with same IDs to be replaced during game countdown

### DIFF
--- a/frontend/prebuild/src/app/entity/player.ts
+++ b/frontend/prebuild/src/app/entity/player.ts
@@ -65,8 +65,10 @@ export class Player {
       this.explosionImage = Assets.PLAYER_DEAD_BITMAP.clone();
       this.explosionImage.scaleX = 1 / 5;
       this.explosionImage.scaleY = 1 / 5;
-      this.explosionImage.regX = this.explosionImage.getBounds().width / 2;
-      this.explosionImage.regY = this.explosionImage.getBounds().height / 2;
+      if (this.explosionImage.getBounds() !== null) {
+          this.explosionImage.regX = this.explosionImage.getBounds().width / 2;
+          this.explosionImage.regY = this.explosionImage.getBounds().height / 2;
+      }
       this.childrenLoaded = true;
     }
 

--- a/game-service/src/main/java/org/libertybikes/game/core/GameRound.java
+++ b/game-service/src/main/java/org/libertybikes/game/core/GameRound.java
@@ -167,11 +167,20 @@ public class GameRound implements Runnable {
             return false;
         }
 
-        for (Client c : clients.values())
+        Client replaceClient = null;
+        for (Client c : clients.values()) {
             if (c.player.isPresent() && playerId.equals(c.player.get().id)) {
-                log("Cannot add player " + playerId + " to game because a player with that ID is already in the game.");
-                return false;
+                // If we find a player trying to join a game with the same ID as a player who is already
+                // in the game, assume it was from an AI Bot player who's developer made a hot code update
+                // TODO: once private IDs are implemented, could filter this on playerId.startsWith("BOT:")
+                replaceClient = c;
+                break;
             }
+        }
+        if (replaceClient != null) {
+            log("Replacing client with id: " + playerId);
+            removeClient(replaceClient.session);
+        }
 
         int numPlayers = getPlayers().size() + 1;
         if (numPlayers == Player.MAX_PLAYERS) {

--- a/game-service/src/main/java/org/libertybikes/game/round/service/GameRoundWebsocket.java
+++ b/game-service/src/main/java/org/libertybikes/game/round/service/GameRoundWebsocket.java
@@ -108,7 +108,7 @@ public class GameRoundWebsocket {
                                                      " to game. This is probably because the player has not been registered yet");
                 else if (!round.addPlayer(session, msg.playerJoinedId, playerResponse.name, msg.hasGameBoard == null ? true : msg.hasGameBoard))
                     closeWithError(session, roundId, "Unable to add player " + playerResponse.name
-                                                     + " to game. This is probably because someone else with the same name is already in the game.");
+                                                     + " to game. This is probably because someone else with the same id is already in the game.");
             } else if (Boolean.TRUE == msg.isSpectator) {
                 round.addSpectator(session);
             } else {


### PR DESCRIPTION
This is a big dev exp improvement for the liberty bikes lab, because otherwise if someone makes a hot code update while their bot is waiting in a game countdown (20s window), the app update would fail to register and the developer needs to make another bogus app update after the game starts to trigger the registration flow again.